### PR TITLE
Unmarshal block using golang build-in json library

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,49 @@
+package bitcoinrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+	rpcproto "github.com/wenweih/bitcoin-rpc-golang/proto"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func readTestData() []byte {
+	blockFile, err := os.Open("./testdata/600000.json")
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	defer blockFile.Close()
+	byteValue, _ := ioutil.ReadAll(blockFile)
+	return byteValue
+}
+
+func BenchmarkJsonUnmarshal(b *testing.B) {
+	byteValue := readTestData()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var blockResult btcjson.GetBlockVerboseTxResult
+		err := json.Unmarshal(byteValue, &blockResult)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProtojsonUnmarshal(b *testing.B) {
+	byteValue := readTestData()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var blockResult rpcproto.GetBlockVerboseTxResult
+		err := protojson.Unmarshal(byteValue, &blockResult)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/block.go
+++ b/block.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	rpcproto "github.com/wenweih/bitcoin-rpc-golang/proto"
 )
@@ -76,7 +75,7 @@ func (r FutureGetBlockVerboseTxResult) Receive() (*rpcproto.GetBlockVerboseTxRes
 	}
 
 	var blockResult rpcproto.GetBlockVerboseTxResult
-	err = protojson.Unmarshal(res, &blockResult)
+	err = json.Unmarshal(res, &blockResult)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Benchmark show that using protojson to unmarshal block data is slower than encoding/json.
```
➜  bitcoin-rpc-golang git:(optimisation/protojson-pool-performance) ✗ go test -bench=. -benchmem                                        
goos: darwin
goarch: amd64
pkg: github.com/wenweih/bitcoin-rpc-golang
BenchmarkJsonUnmarshal-12                     24          47861178 ns/op         8919215 B/op      69935 allocs/op
BenchmarkProtojsonUnmarshal-12                25          49144181 ns/op        10745280 B/op     305890 allocs/op
PASS
ok      github.com/wenweih/bitcoin-rpc-golang   4.073s
```

Also see this [issue](https://github.com/golang/protobuf/issues/1285) reported in protobuf  official repo.